### PR TITLE
Remove "experimental" infix from connector create cli cmd

### DIFF
--- a/3_create_connector.sh
+++ b/3_create_connector.sh
@@ -3,5 +3,5 @@
 ibmcloud target -g default
 echo "If the target command failed, check what resource groups you have and target that. ibmcloud resource groups";
 # Make a connector. 
-ibmcloud sat experimental connector create --name connector123 --region us-east
+ibmcloud sat connector create --name connector123 --region us-east
 echo "The connectorID needs to go in ./env-files/env.txt";


### PR DESCRIPTION
Avoid the following error -

> FAILED
This experimental command is deactivated as of 2024-11-18. Please use 'ibmcloud sat connector create' instead.